### PR TITLE
Allow limit greater than api max (20)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "cryptokitties": "index.js"
   },
   "engines": {
-    "node": ">=6.x.x"
+    "node": ">=7.6.x"
   },
   "engineStrict": true,
   "dependencies": {

--- a/util.js
+++ b/util.js
@@ -1,14 +1,20 @@
 var cryptokittiesContrib = require("cryptokitties-contrib");
 var ck = new cryptokittiesContrib();
-
-var apiCall = function (argv){
-  ck.listAuctions(type = "sale", status="open", limit=argv.limit, offset=0, orderBy=argv.orderBy, orderDirection=argv.orderDirection, search=argv.keywords)
-  .then(function(arrayOfAuctions) {
-    if(argv.pretty){
-      arrayOfAuctions = arrayOfAuctions.map(prettyPrice);
-    }
-    console.log(JSON.stringify(arrayOfAuctions, null, 2))
-  })
+const MAX = 20
+var apiCall = async function (argv){
+  var results =[];
+  for(var i = 0; i<= Math.floor(argv.limit/MAX); i++) {
+    var offset = i*MAX
+    var limit = (offset+MAX>argv.limit) ? (argv.limit % MAX) : MAX
+    var set = await ck.listAuctions(type = "sale", status="open", limit=limit, offset=offset, orderBy=argv.orderBy, orderDirection=argv.orderDirection, search=argv.keywords)
+    results = results.concat(set)
+    var delay = await new Promise((resolve) => setTimeout(resolve, 2500))
+  }
+  if(argv.pretty){
+   results = results.map(prettyPrice);
+  }
+  console.log(JSON.stringify(results, null, 2))
+  return results
 }
 
 var coerceSort = function(argv){


### PR DESCRIPTION
Dependes on #15 , closes #13

Ive tried writing this in promises in the past which would remove the need for the node version bump, but its very difficult to write generative promises and I gave up for async await which is very clean.

Node 7.6 Brings Default Async/Await Support, So I have to up us to 7.6

async command handlers are in yargs as of  10.1 so were good there too already
