### PR TITLE
hack coerces into yargs middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,9 +10,7 @@ var argv = require('yargs')
       choices: (["youngest", "oldest", "cheapest", "expensive", "likes"]),
       default: 'youngest'
     })
-    //coerce sadly scopes you to one variable so hack here to alter two
-    yargs.argv = util.coerceSort(yargs.argv)
-  }, util.apiCall)
+  }, util.apiCall, [util.coerceSort])
   .command('api', 'low level api access', (yargs) => {
     yargs.positional('orderBy', {
       describe: 'Choose an option',
@@ -24,9 +22,7 @@ var argv = require('yargs')
       choices: (["desc", "asc"]),
       default: 'asc'
     })
-    //coerce doesnt let you coerce to a non existing choice, so hack here
-    yargs.argv = util.coerceOrderBy(yargs.argv)
-  }, util.apiCall)
+  }, util.apiCall, [util.coerceOrderBy])
   .option('limit', {
     default: 20
   })


### PR DESCRIPTION
hacky fix in 63fd6c2 didnt fix the hacky coerce problems. Orderby with age is still triggering the yargs check against an empty value which isnt in our options list.

```
bash-3.2$ node index.js api --orderBy=age orderDirection=desc  --limit 1 -p
Positionals:
  orderBy         Choose an option
      [choices: "purr_count", "current_price", "age"] [default: "current_price"]
  orderDirection  Choose a direction   [choices: "desc", "asc"] [default: "asc"]

Options:
  --help        Show help                                              [boolean]
  --version     Show version number                                    [boolean]
  --limit                                                          [default: 20]
  --keywords                                                       [default: ""]
  --pretty, -p                                                  [default: false]

Invalid values:
  Argument: orderBy, Given: "", Choices: "purr_count", "current_price", "age"
bash-3.2$ 
```

Lets hack the new middleware api and coerce our arguments in there
